### PR TITLE
🔧 ci: Add source_folder parameter for coverage path remapping

### DIFF
--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -78,6 +78,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: unit-test
+      source_folder: src
 
   integration-test_codecov:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
@@ -89,6 +90,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: integration-test
+      source_folder: src
 
   e2e-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -100,6 +102,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: e2e-test
+      source_folder: src
 
   contract-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -111,6 +114,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: contract-test
+      source_folder: src
 
   all_test_not_e2e_test_codecov:
 #    name: Organize and generate the testing report and upload it to Codecov
@@ -126,6 +130,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: all-test
+      source_folder: src
 
   all_test_include_e2e_test_codecov:
 #    name: Organize and generate the testing report and upload it to Codecov
@@ -141,3 +146,4 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: all-test
+      source_folder: src


### PR DESCRIPTION
## _Target_

Add `source_folder` parameter to coverage organization workflow for correct path remapping.

* ### Task summary:
    Update coverage workflow to use `src/` as source folder.

* ### Task tickets:
    * Upstream: GitHub-Action_Reusable_Workflows-Python#156

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🤖 CI/CD

## _Description_

✅ Correct coverage path mapping for `src/` folder